### PR TITLE
Make ACL library name dependent on OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Rust FFI interface for POSIX Access Control Lists. This is LGPL 2.1 because the
-ACL library is LGPL 2.1.
+Linux ACL library is LGPL 2.1.
 
 Documentation: https://stebalien.github.io/acl-sys/acl_sys/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@ pub const ACL_OTHER: acl_tag_t = 0x20;
 pub const ACL_FIRST_ENTRY: c_int = 0;
 pub const ACL_NEXT_ENTRY: c_int = 1;
 
-#[link(name = "acl")]
+// On Linux link to libacl, other OSes have this in libc and need no annotation
+#[cfg_attr(target_os = "linux", link(name = "acl"))]
 extern "C" {
     /*=== ACL manipulation ===*/
 


### PR DESCRIPTION
* On Linux, link to libacl
* On FreeBSD and macOS these symbols require no link annotation

The behavior of these calls is wildly different on each platform, but maybe this will be useful for somebody.

Also added minor note about ACL library license.