### PR TITLE
Added acl_to_any_text and acl_get_perm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,13 @@ extern "C" {
     pub fn acl_get_entry(acl: acl_t, entry_id: c_int, entry: *mut acl_entry_t) -> c_int;
 
     /* Manipulate ACL entry permissions */
-
     pub fn acl_add_perm(permset: acl_permset_t, perm: acl_perm_t) -> c_int;
     pub fn acl_calc_mask(acl: *mut acl_t) -> c_int;
     pub fn acl_clear_perms(permset: acl_permset_t) -> c_int;
     pub fn acl_delete_perms(permset: acl_permset_t, perm: acl_perm_t) -> c_int;
     pub fn acl_get_permset(entry: acl_entry_t, permset: *mut acl_permset_t) -> c_int;
     pub fn acl_set_permset(entry: acl_entry_t, permset: acl_permset_t) -> c_int;
+    pub fn acl_get_perm(permset: acl_permset_t, perm: acl_perm_t) -> c_int;
 
     /* Manipulate ACL entry tag type and qualifier */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ extern "C" {
     pub fn acl_from_text(buf: *const c_char) -> acl_t;
     pub fn acl_size(acl: acl_t) -> ssize_t;
     pub fn acl_to_text(acl: acl_t, len: *mut ssize_t) -> *mut c_char;
+    pub fn acl_to_any_text(acl: acl_t, prefix:*const c_char, separator: c_char, options:c_int) -> *mut c_char;
 
     /*=== Object manipulation ===*/
 


### PR DESCRIPTION
Hi, 
I found that the two functions acl_to_any_text and acl_get_perm were missing.  Here is a PR to fix that.
Regards,
Sojan